### PR TITLE
Fix Supabase client import to resolve build errors

### DIFF
--- a/src/pages/admin/AdminPage.tsx
+++ b/src/pages/admin/AdminPage.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react'
-import { createClient } from '@/lib/supabase/client'
+import { supabase } from '@/lib/supabase/client'
 import { logError } from '@/lib/utils/errorUtils'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
@@ -59,7 +59,7 @@ export default function AdminPage() {
       setLoading(true)
       setError(null)
 
-      const supabase = createClient()
+      // Use the supabase client
 
       // Fetch properties
       const { data: propertiesData, error: propertiesError } = await supabase

--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -5,13 +5,13 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { createClient } from '@/lib/supabase/client'
+import { supabase } from '@/lib/supabase/client'
 import { Eye, EyeOff, Mail, Lock, User, Phone } from 'lucide-react'
 
 export default function SignInPage() {
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
-  const supabase = createClient()
+  // Use the imported supabase client
 
   const redirectTo = searchParams.get('redirectedFrom') || '/'
   


### PR DESCRIPTION
## Purpose
Fix TypeScript build errors in Vercel deployment caused by incorrect Supabase client usage. The build was failing due to `createClient()` being called without required arguments in AdminPage.tsx and SignInPage.tsx.

## Code changes
- **AdminPage.tsx**: Replace `createClient()` call with direct import and usage of `supabase` client
- **SignInPage.tsx**: Replace `createClient()` call with direct import and usage of `supabase` client
- Updated imports from `createClient` to `supabase` in both files
- Removed local client instantiation in favor of using the pre-configured client

This resolves the TS2554 errors where `createClient()` expected 2-3 arguments but received 0.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 11`

🔗 [Edit in Builder.io](https://builder.io/app/projects/c6552a73f9b94a90ac1051ced09fbd2a/quantum-works)

👀 [Preview Link](https://c6552a73f9b94a90ac1051ced09fbd2a-quantum-works.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>c6552a73f9b94a90ac1051ced09fbd2a</projectId>-->
<!--<branchName>quantum-works</branchName>-->